### PR TITLE
Refactor: Migrate dashboard to Vue 3, Vite, and Tailwind CSS

### DIFF
--- a/vue-tailwind-dashboard/.gitignore
+++ b/vue-tailwind-dashboard/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/vue-tailwind-dashboard/.vscode/extensions.json
+++ b/vue-tailwind-dashboard/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["Vue.volar"]
+}

--- a/vue-tailwind-dashboard/README.md
+++ b/vue-tailwind-dashboard/README.md
@@ -1,0 +1,5 @@
+# Vue 3 + Vite
+
+This template should help get you started developing with Vue 3 in Vite. The template uses Vue 3 `<script setup>` SFCs, check out the [script setup docs](https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup) to learn more.
+
+Learn more about IDE Support for Vue in the [Vue Docs Scaling up Guide](https://vuejs.org/guide/scaling-up/tooling.html#ide-support).

--- a/vue-tailwind-dashboard/index.html
+++ b/vue-tailwind-dashboard/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Vue</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/vue-tailwind-dashboard/package-lock.json
+++ b/vue-tailwind-dashboard/package-lock.json
@@ -1,0 +1,1649 @@
+{
+  "name": "vue-tailwind-dashboard",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vue-tailwind-dashboard",
+      "version": "0.0.0",
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
+        "@fortawesome/vue-fontawesome": "^3.0.8",
+        "chart.js": "^4.5.0",
+        "pinia": "^3.0.3",
+        "vue": "^3.5.17",
+        "vue-router": "^4.5.1"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^6.0.0",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.10",
+        "vite": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+      "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.8.tgz",
+      "integrity": "sha512-yyHHAj4G8pQIDfaIsMvQpwKMboIZtcHTUvPqXjOHyldh1O1vZfH4W03VDPv5RvI9P6DLTzJQlmVgj9wCf7c2Fw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "vue": ">= 3.0.0 < 4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
+      "integrity": "sha512-3FL3mnMbPu0muGOCaKAhhFEYmqv9eTfPSJRJmANrCwtgK8VuxpsZDGK+m0LYAGoyO8+0j5uRe4PeyPDK1yA/hA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.0.tgz",
+      "integrity": "sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.0.tgz",
+      "integrity": "sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.0.tgz",
+      "integrity": "sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.0.tgz",
+      "integrity": "sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.0.tgz",
+      "integrity": "sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.0.tgz",
+      "integrity": "sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.0.tgz",
+      "integrity": "sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.0.tgz",
+      "integrity": "sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.0.tgz",
+      "integrity": "sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.0.tgz",
+      "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.0.tgz",
+      "integrity": "sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.0.tgz",
+      "integrity": "sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.0.tgz",
+      "integrity": "sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.0.tgz",
+      "integrity": "sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.0.tgz",
+      "integrity": "sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.0.tgz",
+      "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.0.tgz",
+      "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.0.tgz",
+      "integrity": "sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.0.tgz",
+      "integrity": "sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.0.tgz",
+      "integrity": "sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.0.tgz",
+      "integrity": "sha512-iAliE72WsdhjzTOp2DtvKThq1VBC4REhwRcaA+zPAAph6I+OQhUXv+Xu2KS7ElxYtb7Zc/3R30Hwv1DxEo7NXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-beta.19"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
+      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.5",
+        "@vue/shared": "3.5.17",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
+      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.17",
+        "@vue/shared": "3.5.17"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
+      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.27.5",
+        "@vue/compiler-core": "3.5.17",
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/compiler-ssr": "3.5.17",
+        "@vue/shared": "3.5.17",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.17",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
+      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/shared": "3.5.17"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.7.tgz",
+      "integrity": "sha512-wgoZtxcTta65cnZ1Q6MbAfePVFxfM+gq0saaeytoph7nEa7yMXoi6sCPy4ufO111B9msnw0VOWjPEFCXuAKRHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.7",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.7.tgz",
+      "integrity": "sha512-+udSj47aRl5aKb0memBvcUG9koarqnxNM5yjuREvqwK6T3ap4mn3Zqqc17QrBFTqSMjr3HK1cvStEZpMDpfdyw==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.17.tgz",
+      "integrity": "sha512-l/rmw2STIscWi7SNJp708FK4Kofs97zc/5aEPQh4bOsReD/8ICuBcEmS7KGwDj5ODQLYWVN2lNibKJL1z5b+Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.17"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.17.tgz",
+      "integrity": "sha512-QQLXa20dHg1R0ri4bjKeGFKEkJA7MMBxrKo2G+gJikmumRS7PTD4BOU9FKrDQWMKowz7frJJGqBffYMgQYS96Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.17",
+        "@vue/shared": "3.5.17"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.17.tgz",
+      "integrity": "sha512-8El0M60TcwZ1QMz4/os2MdlQECgGoVHPuLnQBU3m9h3gdNRW9xRmI8iLS4t/22OQlOE6aJvNNlBiCzPHur4H9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.17",
+        "@vue/runtime-core": "3.5.17",
+        "@vue/shared": "3.5.17",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.17.tgz",
+      "integrity": "sha512-BOHhm8HalujY6lmC3DbqF6uXN/K00uWiEeF22LfEsm9Q93XeJ/plHTepGwf6tqFcF7GA5oGSSAAUock3VvzaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.17",
+        "@vue/shared": "3.5.17"
+      },
+      "peerDependencies": {
+        "vue": "3.5.17"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
+      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.4.0.tgz",
+      "integrity": "sha512-5IdNxTyhXHv2UlgnPHQ0h+5ypVmkrYHzL8QT+DwFZ//2N/oNV8Ch+BCRmTJ3x6/z9Axo/cXYBc9eprsUVK/Jsg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001726",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.175",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.175.tgz",
+      "integrity": "sha512-Nqpef9mOVo7pZfl9NIUhj7tgtRTsMzCzRTJDP1ccim4Wb4YHOz3Le87uxeZq68OCNwau2iQ/X7UwdAZ3ReOkmg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.5",
+        "@esbuild/android-arm": "0.25.5",
+        "@esbuild/android-arm64": "0.25.5",
+        "@esbuild/android-x64": "0.25.5",
+        "@esbuild/darwin-arm64": "0.25.5",
+        "@esbuild/darwin-x64": "0.25.5",
+        "@esbuild/freebsd-arm64": "0.25.5",
+        "@esbuild/freebsd-x64": "0.25.5",
+        "@esbuild/linux-arm": "0.25.5",
+        "@esbuild/linux-arm64": "0.25.5",
+        "@esbuild/linux-ia32": "0.25.5",
+        "@esbuild/linux-loong64": "0.25.5",
+        "@esbuild/linux-mips64el": "0.25.5",
+        "@esbuild/linux-ppc64": "0.25.5",
+        "@esbuild/linux-riscv64": "0.25.5",
+        "@esbuild/linux-s390x": "0.25.5",
+        "@esbuild/linux-x64": "0.25.5",
+        "@esbuild/netbsd-arm64": "0.25.5",
+        "@esbuild/netbsd-x64": "0.25.5",
+        "@esbuild/openbsd-arm64": "0.25.5",
+        "@esbuild/openbsd-x64": "0.25.5",
+        "@esbuild/sunos-x64": "0.25.5",
+        "@esbuild/win32-arm64": "0.25.5",
+        "@esbuild/win32-ia32": "0.25.5",
+        "@esbuild/win32-x64": "0.25.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.3.tgz",
+      "integrity": "sha512-ttXO/InUULUXkMHpTdp9Fj4hLpD/2AoJdmAbAeW2yu1iy1k+pkFekQXw5VpC0/5p51IOR/jDaDRfRWRnMMsGOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.4.4",
+        "vue": "^2.7.0 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.7.tgz",
+      "integrity": "sha512-lwOnNBH2e7x1fIIbVT7yF5D+YWhqELm55/4ZKf45R9T8r9dE2AIOy8HKjfqzGsoTHFbWbr337O4E0A0QADnjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.7"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.44.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.0.tgz",
+      "integrity": "sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.44.0",
+        "@rollup/rollup-android-arm64": "4.44.0",
+        "@rollup/rollup-darwin-arm64": "4.44.0",
+        "@rollup/rollup-darwin-x64": "4.44.0",
+        "@rollup/rollup-freebsd-arm64": "4.44.0",
+        "@rollup/rollup-freebsd-x64": "4.44.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.44.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.44.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.44.0",
+        "@rollup/rollup-linux-arm64-musl": "4.44.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.44.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.44.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.44.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.44.0",
+        "@rollup/rollup-linux-x64-gnu": "4.44.0",
+        "@rollup/rollup-linux-x64-musl": "4.44.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.44.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.44.0",
+        "@rollup/rollup-win32-x64-msvc": "4.44.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.2.tgz",
+      "integrity": "sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
+      "integrity": "sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.0.tgz",
+      "integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.6",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.6",
+        "rollup": "^4.40.0",
+        "tinyglobby": "^0.2.14"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.17.tgz",
+      "integrity": "sha512-LbHV3xPN9BeljML+Xctq4lbz2lVHCR6DtbpTf5XIO6gugpXUN49j2QQPcMj086r9+AkJ0FfUT8xjulKKBkkr9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.17",
+        "@vue/compiler-sfc": "3.5.17",
+        "@vue/runtime-dom": "3.5.17",
+        "@vue/server-renderer": "3.5.17",
+        "@vue/shared": "3.5.17"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
+    }
+  }
+}

--- a/vue-tailwind-dashboard/package.json
+++ b/vue-tailwind-dashboard/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "vue-tailwind-dashboard",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
+    "@fortawesome/vue-fontawesome": "^3.0.8",
+    "chart.js": "^4.5.0",
+    "pinia": "^3.0.3",
+    "vue": "^3.5.17",
+    "vue-router": "^4.5.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.0",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.10",
+    "vite": "^7.0.0"
+  }
+}

--- a/vue-tailwind-dashboard/postcss.config.js
+++ b/vue-tailwind-dashboard/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+      plugins: {
+        tailwindcss: {},
+        autoprefixer: {},
+      },
+    }

--- a/vue-tailwind-dashboard/src/App.vue
+++ b/vue-tailwind-dashboard/src/App.vue
@@ -1,0 +1,55 @@
+<template>
+  <div id="app-container" class="antialiased text-slate-700">
+    <AppHeader />
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <router-view v-slot="{ Component }">
+        <transition name="fade" mode="out-in">
+          <component :is="Component" />
+        </transition>
+      </router-view>
+    </div>
+    <ConfirmationModal />
+    <TransactionForm />
+    <!-- TransactionForm might be better handled locally in views that need it,
+         or its visibility controlled by a global store.
+         For now, including it here if its state is managed globally as in original.
+         Alternatively, remove from here and place where 'showTransactionForm' is managed. -->
+  </div>
+</template>
+
+<script setup>
+import AppHeader from './components/AppHeader.vue';
+// Assuming ConfirmationModal and TransactionForm state will be managed via a store or provide/inject later
+// For now, let's assume they are self-contained or will be connected to a store
+import ConfirmationModal from './components/ConfirmationModal.vue';
+import TransactionForm from './components/TransactionForm.vue';
+
+// It's good practice to define transitions in a global CSS or here if scoped
+</script>
+
+<style>
+/* Global transitions (can also be in assets/css/main.css) */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.slide-fade-enter-active {
+  transition: all 0.3s ease-out;
+}
+
+.slide-fade-leave-active {
+  transition: all 0.3s cubic-bezier(1, 0.5, 0.8, 1);
+}
+
+.slide-fade-enter-from,
+.slide-fade-leave-to {
+  transform: translateY(-20px);
+  opacity: 0;
+}
+</style>

--- a/vue-tailwind-dashboard/src/assets/css/main.css
+++ b/vue-tailwind-dashboard/src/assets/css/main.css
@@ -1,0 +1,13 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Custom base styles if any */
+body {
+    background-color: #f1f5f9; /* slate-100 from original */
+    /* Consider moving fade/slide transitions here if they are global */
+}
+
+[v-cloak] {
+    display: none;
+}

--- a/vue-tailwind-dashboard/src/components/AppHeader.vue
+++ b/vue-tailwind-dashboard/src/components/AppHeader.vue
@@ -1,0 +1,54 @@
+<template>
+  <header class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-6 px-4 sm:px-6 lg:px-8 pt-8">
+    <div>
+      <h1 class="text-3xl font-bold text-slate-800">Dashboard de Gastos</h1>
+      <p class="text-slate-500">Gestiona las finanzas de tu familia.</p>
+    </div>
+    <div class="flex items-center flex-wrap gap-2 mt-4 sm:mt-0">
+      <DataImportExport />
+
+      <nav class="flex space-x-1 sm:space-x-2 bg-slate-200 p-1 rounded-lg ml-2">
+        <router-link
+          to="/"
+          class="px-3 py-2 text-sm font-semibold rounded-md transition-colors"
+          :class="$route.name === 'Dashboard' ? 'bg-white shadow text-blue-700' : 'text-slate-600 hover:bg-slate-300'"
+        >
+          Dashboard
+        </router-link>
+        <router-link
+          to="/charts"
+          class="px-3 py-2 text-sm font-semibold rounded-md transition-colors"
+          :class="$route.name === 'Charts' ? 'bg-white shadow text-blue-700' : 'text-slate-600 hover:bg-slate-300'"
+        >
+          Gráficos
+        </router-link>
+        <router-link
+          to="/members"
+          class="px-3 py-2 text-sm font-semibold rounded-md transition-colors"
+          :class="$route.name === 'Members' ? 'bg-white shadow text-blue-700' : 'text-slate-600 hover:bg-slate-300'"
+        >
+          Miembros
+        </router-link>
+        <router-link
+          to="/categories"
+          class="px-3 py-2 text-sm font-semibold rounded-md transition-colors"
+          :class="$route.name === 'Categories' ? 'bg-white shadow text-blue-700' : 'text-slate-600 hover:bg-slate-300'"
+        >
+          Categorías
+        </router-link>
+      </nav>
+    </div>
+  </header>
+</template>
+
+<script setup>
+import DataImportExport from './DataImportExport.vue';
+</script>
+
+<style scoped>
+/* Using :class for active links, so router-link-exact-active might not be needed unless preferred */
+a.text-slate-600.hover\:bg-slate-300.router-link-exact-active {
+    /* This is an example if you wanted to target the non-active-class styled active link */
+    /* For this setup, rely on the conditional :class binding and active-class is not used here */
+}
+</style>

--- a/vue-tailwind-dashboard/src/components/CategoryList.vue
+++ b/vue-tailwind-dashboard/src/components/CategoryList.vue
@@ -1,0 +1,29 @@
+<template>
+  <aside class="bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+    <h2 class="text-xl font-bold mb-4 text-slate-800">Gastos por Categoría</h2>
+    <div v-if="store.totalExpense > 0" class="space-y-4">
+      <div v-for="(amount, category) in store.expensesByCategory" :key="category">
+        <div class="flex justify-between items-center mb-1">
+          <span class="text-sm font-medium">{{ category }}</span>
+          <span class="text-sm font-mono">{{ fCurrency(amount) }}</span>
+        </div>
+        <div class="w-full bg-slate-200 rounded-full h-2.5">
+          <div
+            class="h-2.5 rounded-full"
+            :style="{ width: (amount / store.totalExpense * 100) + '%', backgroundColor: store.getCategoryColor(category) }"
+          ></div>
+        </div>
+      </div>
+    </div>
+    <div v-else class="text-center py-8 text-slate-500">
+      <p>No hay gastos registrados en el periodo seleccionado.</p>
+    </div>
+  </aside>
+</template>
+
+<script setup>
+import { useMainStore } from '../store/mainStore';
+import { formatCurrency as fCurrency } from '../utils/formatters';
+
+const store = useMainStore();
+</script>

--- a/vue-tailwind-dashboard/src/components/CategoryManager.vue
+++ b/vue-tailwind-dashboard/src/components/CategoryManager.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <form @submit.prevent="saveCategory" class="flex flex-col sm:flex-row items-end gap-4 mb-8 p-4 bg-slate-50 rounded-lg">
+      <div class="w-full">
+        <label for="categoryName" class="block text-sm font-medium text-slate-600 mb-1">Nombre de la Categoría</label>
+        <input v-model="categoryForm.name" type="text" id="categoryName" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" placeholder="Ej: Supermercado" required>
+      </div>
+      <div class="w-full sm:w-auto">
+        <label for="categoryColor" class="block text-sm font-medium text-slate-600 mb-1">Color</label>
+        <input v-model="categoryForm.color" type="color" id="categoryColor" class="w-full h-10 px-1 py-1 border border-slate-300 rounded-lg cursor-pointer">
+      </div>
+      <div class="flex gap-2 w-full sm:w-auto shrink-0">
+        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg flex-grow">
+          {{ categoryForm.isEditing ? 'Actualizar' : 'Añadir' }}
+        </button>
+        <button v-if="categoryForm.isEditing" @click="cancelEditCategory" type="button" class="w-full bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold py-2 px-4 rounded-lg">
+          Cancelar
+        </button>
+      </div>
+    </form>
+
+    <ul class="space-y-3">
+      <li v-if="store.categories.length === 0" class="text-center py-8 text-slate-500">
+        No hay categorías añadidas.
+      </li>
+      <li v-for="cat in store.categories" :key="cat.name" class="flex justify-between items-center p-3 bg-white border border-slate-200 rounded-lg hover:shadow-sm">
+        <div class="flex items-center gap-3">
+          <span class="block w-5 h-5 rounded-full border border-slate-200" :style="{ backgroundColor: cat.color }"></span>
+          <span class="font-medium text-slate-700">{{ cat.name }}</span>
+        </div>
+        <div class="flex gap-4">
+          <button @click="editCategory(cat)" class="text-slate-500 hover:text-blue-600 transition-colors">
+            <font-awesome-icon icon="pencil-alt" />
+          </button>
+          <button @click="askToDeleteCategory(cat.name)" class="text-slate-500 hover:text-red-600 transition-colors">
+            <font-awesome-icon icon="trash-alt" />
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useMainStore } from '../store/mainStore';
+
+const store = useMainStore();
+const categoryForm = ref({ name: '', color: '#94a3b8', isEditing: false, originalName: '' });
+
+const defaultColor = '#94a3b8';
+
+const saveCategory = () => {
+  const newName = categoryForm.value.name.trim();
+  if (!newName) return;
+
+  const categoryData = { name: newName, color: categoryForm.value.color || defaultColor };
+
+  let success = false;
+  if (categoryForm.value.isEditing) {
+    success = store.updateCategory(categoryForm.value.originalName, categoryData);
+  } else {
+     if (store.categories.some(c => c.name === newName)) {
+      alert('Ese nombre de categoría ya existe.');
+    } else {
+      store.addCategory(categoryData);
+      success = true;
+    }
+  }
+
+  if (success) {
+    cancelEditCategory();
+  }
+};
+
+const editCategory = (category) => {
+  categoryForm.value.name = category.name;
+  categoryForm.value.color = category.color || defaultColor;
+  categoryForm.value.originalName = category.name;
+  categoryForm.value.isEditing = true;
+};
+
+const cancelEditCategory = () => {
+  categoryForm.value.name = '';
+  categoryForm.value.color = defaultColor;
+  categoryForm.value.isEditing = false;
+  categoryForm.value.originalName = '';
+};
+
+const askToDeleteCategory = (categoryName) => {
+  store.openConfirmModal(
+    'Eliminar Categoría',
+    `¿Estás seguro de que quieres eliminar la categoría "${categoryName}"?`,
+    () => {
+      store.deleteCategory(categoryName);
+      if (categoryForm.value.isEditing && categoryForm.value.originalName === categoryName) {
+        cancelEditCategory();
+      }
+    }
+  );
+};
+</script>

--- a/vue-tailwind-dashboard/src/components/ConfirmationModal.vue
+++ b/vue-tailwind-dashboard/src/components/ConfirmationModal.vue
@@ -1,0 +1,52 @@
+<template>
+  <transition name="fade">
+    <div
+      v-if="store.showConfirmModal"
+      @click.self="store.closeConfirmModal()"
+      class="fixed inset-0 bg-black bg-opacity-60 z-50 flex justify-center items-center p-4"
+    >
+      <transition name="slide-fade">
+        <div v-if="store.showConfirmModal" class="bg-white rounded-xl shadow-2xl p-6 sm:p-8 w-full max-w-md text-center">
+          <h3 class="text-xl font-bold mb-4 text-slate-800">{{ store.confirmModalProps.title }}</h3>
+          <p class="text-slate-600 mb-6">{{ store.confirmModalProps.message }}</p>
+          <div class="flex justify-center space-x-4">
+            <button
+              @click="store.closeConfirmModal()"
+              class="px-6 py-2 bg-slate-200 hover:bg-slate-300 text-slate-700 font-semibold rounded-lg"
+            >
+              Cancelar
+            </button>
+            <button
+              @click="handleConfirm"
+              class="px-6 py-2 text-white font-semibold rounded-lg shadow-sm"
+              :class="confirmButtonClass"
+            >
+              Confirmar
+            </button>
+          </div>
+        </div>
+      </transition>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useMainStore } from '../store/mainStore';
+
+const store = useMainStore();
+
+const handleConfirm = () => {
+  store.executeConfirm();
+};
+
+// Optional: Add dynamic styling for confirm button based on action type (e.g., delete vs. generic confirm)
+const confirmButtonClass = computed(() => {
+  // Example: make button red if title includes 'Eliminar' or 'Vaciar'
+  const title = store.confirmModalProps.title.toLowerCase();
+  if (title.includes('eliminar') || title.includes('vaciar') || title.includes('delete')) {
+    return 'bg-red-600 hover:bg-red-700';
+  }
+  return 'bg-blue-600 hover:bg-blue-700'; // Default confirm color
+});
+</script>

--- a/vue-tailwind-dashboard/src/components/DataImportExport.vue
+++ b/vue-tailwind-dashboard/src/components/DataImportExport.vue
@@ -1,0 +1,44 @@
+<template>
+  <div class="flex items-center gap-2 border border-slate-300 rounded-lg p-1">
+    <button
+      @click="handleExport"
+      title="Exportar datos a un archivo JSON"
+      class="bg-white hover:bg-slate-100 text-slate-600 font-semibold py-1.5 px-3 rounded-md flex items-center text-sm"
+    >
+      <font-awesome-icon icon="file-export" class="mr-2" />
+      Exportar
+    </button>
+    <button
+      @click="triggerImport"
+      title="Importar datos desde un archivo JSON"
+      class="bg-white hover:bg-slate-100 text-slate-600 font-semibold py-1.5 px-3 rounded-md flex items-center text-sm"
+    >
+      <font-awesome-icon icon="file-import" class="mr-2" />
+      Importar
+    </button>
+    <input type="file" ref="fileInput" @change="onFileChange" accept=".json" class="hidden">
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useMainStore } from '../store/mainStore';
+
+const store = useMainStore();
+const fileInput = ref(null);
+
+const handleExport = () => {
+  store.exportData(); // Action from Pinia store
+};
+
+const triggerImport = () => {
+  fileInput.value.click();
+};
+
+const onFileChange = (event) => {
+  const file = event.target.files[0];
+  if (!file) return;
+  store.handleFileUpload(file); // Action from Pinia store
+  event.target.value = ''; // Reset file input
+};
+</script>

--- a/vue-tailwind-dashboard/src/components/DateFilter.vue
+++ b/vue-tailwind-dashboard/src/components/DateFilter.vue
@@ -1,0 +1,51 @@
+<template>
+  <section class="bg-white p-4 rounded-xl shadow-lg border border-slate-200 mb-8 flex flex-col sm:flex-row items-center gap-4">
+    <h3 class="text-sm font-bold text-slate-600 shrink-0">Filtrar por Fecha:</h3>
+    <div class="flex items-center gap-2 w-full">
+      <label for="filterStartDate" class="text-sm font-medium">Desde:</label>
+      <input
+        type="date"
+        v-model="startDate"
+        id="filterStartDate"
+        class="w-full px-3 py-1.5 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 text-sm"
+      >
+    </div>
+    <div class="flex items-center gap-2 w-full">
+      <label for="filterEndDate" class="text-sm font-medium">Hasta:</label>
+      <input
+        type="date"
+        v-model="endDate"
+        id="filterEndDate"
+        class="w-full px-3 py-1.5 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 text-sm"
+      >
+    </div>
+    <button
+      @click="resetFilters"
+      class="w-full sm:w-auto bg-slate-200 hover:bg-slate-300 text-slate-700 font-semibold py-2 px-4 rounded-lg text-sm"
+    >
+      Limpiar
+    </button>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useMainStore } from '../store/mainStore';
+
+const store = useMainStore();
+
+// Create computed properties with getters and setters to bind to store state
+const startDate = computed({
+  get: () => store.filterStartDate,
+  set: (value) => store.filterStartDate = value
+});
+
+const endDate = computed({
+  get: () => store.filterEndDate,
+  set: (value) => store.filterEndDate = value
+});
+
+const resetFilters = () => {
+  store.resetDateFilters();
+};
+</script>

--- a/vue-tailwind-dashboard/src/components/MemberListManager.vue
+++ b/vue-tailwind-dashboard/src/components/MemberListManager.vue
@@ -1,0 +1,90 @@
+<template>
+  <div>
+    <form @submit.prevent="saveMember" class="flex flex-col sm:flex-row items-end gap-4 mb-8 p-4 bg-slate-50 rounded-lg">
+      <div class="w-full">
+        <label for="memberName" class="block text-sm font-medium text-slate-600 mb-1">Nombre del Miembro</label>
+        <input v-model="memberForm.name" type="text" id="memberName" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" placeholder="Ej: Abuela" required>
+      </div>
+      <div class="flex gap-2 w-full sm:w-auto shrink-0">
+        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg flex-grow">
+          {{ memberForm.isEditing ? 'Actualizar' : 'Añadir' }}
+        </button>
+        <button v-if="memberForm.isEditing" @click="cancelEditMember" type="button" class="w-full bg-slate-200 hover:bg-slate-300 text-slate-700 font-bold py-2 px-4 rounded-lg">
+          Cancelar
+        </button>
+      </div>
+    </form>
+
+    <ul class="space-y-3">
+      <li v-if="store.members.length === 0" class="text-center py-8 text-slate-500">
+        No hay miembros añadidos.
+      </li>
+      <li v-for="member in store.members" :key="member" class="flex justify-between items-center p-3 bg-white border border-slate-200 rounded-lg hover:shadow-sm">
+        <span class="font-medium text-slate-700">{{ member }}</span>
+        <div class="flex gap-4">
+          <button @click="editMember(member)" class="text-slate-500 hover:text-blue-600 transition-colors">
+            <font-awesome-icon icon="pencil-alt" />
+          </button>
+          <button @click="askToDeleteMember(member)" class="text-slate-500 hover:text-red-600 transition-colors">
+            <font-awesome-icon icon="trash-alt" />
+          </button>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useMainStore } from '../store/mainStore';
+
+const store = useMainStore();
+const memberForm = ref({ name: '', isEditing: false, originalName: '' });
+
+const saveMember = () => {
+  const newName = memberForm.value.name.trim();
+  if (!newName) return;
+
+  let success = false;
+  if (memberForm.value.isEditing) {
+    success = store.updateMember(memberForm.value.originalName, newName);
+  } else {
+    if (store.members.includes(newName)) {
+      alert('Este miembro ya existe.');
+    } else {
+      store.addMember(newName);
+      success = true;
+    }
+  }
+  if (success) {
+    cancelEditMember();
+  }
+};
+
+const editMember = (memberName) => {
+  memberForm.value.name = memberName;
+  memberForm.value.originalName = memberName;
+  memberForm.value.isEditing = true;
+};
+
+const cancelEditMember = () => {
+  memberForm.value.name = '';
+  memberForm.value.isEditing = false;
+  memberForm.value.originalName = '';
+};
+
+const askToDeleteMember = (memberName) => {
+  // The check for transactions associated with member is in store.deleteMember
+  store.openConfirmModal(
+    'Eliminar Miembro',
+    `¿Estás seguro de que quieres eliminar a "${memberName}"?`,
+    () => {
+      store.deleteMember(memberName);
+      // If current editing member is the one deleted, cancel edit mode
+      if (memberForm.value.isEditing && memberForm.value.originalName === memberName) {
+        cancelEditMember();
+      }
+    }
+  );
+};
+</script>

--- a/vue-tailwind-dashboard/src/components/StatsCard.vue
+++ b/vue-tailwind-dashboard/src/components/StatsCard.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+    <div class="flex items-center">
+      <div class="p-3 rounded-full" :class="iconBgColor">
+        <font-awesome-icon :icon="icon" class="fa-lg" :class="iconTextColor" />
+      </div>
+      <div class="ml-4">
+        <h3 class="text-sm font-medium text-slate-500">{{ title }}</h3>
+        <p class="text-2xl font-bold" :class="valueTextColor">{{ formattedValue }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { formatCurrency } from '../utils/formatters';
+
+const props = defineProps({
+  title: { type: String, required: true },
+  value: { type: Number, required: true },
+  icon: { type: String, required: true },
+  iconBgColor: { type: String, default: 'bg-slate-100' },
+  iconTextColor: { type: String, default: 'text-slate-600' },
+  valueTextColor: { type: String, default: 'text-slate-800' },
+  currency: { type: Boolean, default: true }
+});
+
+const formattedValue = computed(() => {
+  if (props.currency) {
+    return formatCurrency(props.value);
+  }
+  return props.value.toLocaleString('es-PE');
+});
+</script>

--- a/vue-tailwind-dashboard/src/components/TransactionForm.vue
+++ b/vue-tailwind-dashboard/src/components/TransactionForm.vue
@@ -1,0 +1,107 @@
+<template>
+  <transition name="fade">
+    <div
+      v-if="store.showTransactionForm"
+      @click.self="store.showTransactionForm = false"
+      class="fixed inset-0 bg-black bg-opacity-50 z-40 flex justify-center items-center p-4"
+    >
+      <transition name="slide-fade">
+        <div v-if="store.showTransactionForm" class="bg-white rounded-xl shadow-2xl p-6 sm:p-8 w-full max-w-lg">
+          <h2 class="text-2xl font-bold mb-6 text-slate-800">
+            {{ store.transactionForm.isEditing ? 'Editar' : 'Nueva' }} Transacción
+          </h2>
+          <form @submit.prevent="handleSubmit">
+            <div class="mb-4">
+              <label for="description" class="block text-sm font-medium text-slate-600 mb-1">Descripción</label>
+              <input v-model="formData.description" type="text" id="description" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" placeholder="Ej: Compra del supermercado" required>
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+              <div>
+                <label for="amount" class="block text-sm font-medium text-slate-600 mb-1">Monto</label>
+                <input v-model.number="formData.amount" type="number" step="0.01" id="amount" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" placeholder="0.00" required>
+              </div>
+              <div>
+                <label for="date" class="block text-sm font-medium text-slate-600 mb-1">Fecha</label>
+                <input v-model="formData.date" type="date" id="date" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" required>
+              </div>
+            </div>
+            <div class="mb-4">
+              <label for="detail" class="block text-sm font-medium text-slate-600 mb-1">Detalle (Opcional)</label>
+              <textarea v-model="formData.detail" id="detail" rows="2" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" placeholder="Añade notas adicionales aquí..."></textarea>
+            </div>
+            <div class="mb-4">
+              <span class="block text-sm font-medium text-slate-600 mb-2">Tipo</span>
+              <div class="flex space-x-4">
+                <label class="flex items-center">
+                  <input v-model="formData.type" type="radio" value="expense" name="type" class="form-radio h-4 w-4 text-red-600 border-slate-300 focus:ring-red-500">
+                  <span class="ml-2 text-red-700 font-semibold">Gasto</span>
+                </label>
+                <label class="flex items-center">
+                  <input v-model="formData.type" type="radio" value="income" name="type" class="form-radio h-4 w-4 text-green-600 border-slate-300 focus:ring-green-500">
+                  <span class="ml-2 text-green-700 font-semibold">Ingreso</span>
+                </label>
+              </div>
+            </div>
+            <div v-if="formData.type === 'expense'" class="mb-4">
+              <label for="category" class="block text-sm font-medium text-slate-600 mb-1">Categoría</label>
+              <select v-model="formData.category" id="category" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" required>
+                <option disabled value="">Selecciona una categoría</option>
+                <option v-for="cat in store.categories" :key="cat.name" :value="cat.name">{{ cat.name }}</option>
+              </select>
+            </div>
+            <div class="mb-6">
+              <label for="member" class="block text-sm font-medium text-slate-600 mb-1">Miembro</label>
+              <select v-model="formData.member" id="member" class="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" required>
+                <option disabled value="">Selecciona un miembro</option>
+                <option v-for="member in store.members" :key="member" :value="member">{{ member }}</option>
+              </select>
+            </div>
+            <div class="flex justify-end space-x-4">
+              <button @click="store.showTransactionForm = false" type="button" class="px-4 py-2 bg-slate-200 hover:bg-slate-300 text-slate-700 font-semibold rounded-lg">Cancelar</button>
+              <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg shadow-sm">Guardar</button>
+            </div>
+          </form>
+        </div>
+      </transition>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { ref, watch, onMounted } from 'vue';
+import { useMainStore } from '../store/mainStore';
+
+const store = useMainStore();
+
+// Use a local ref for form data, synced with the store's transactionForm
+// This allows local modifications without directly mutating store state outside actions/mutations,
+// and also allows for easier reset/initialization.
+const formData = ref({});
+
+// Watch for changes in the store's transactionForm (e.g., when opening for edit)
+// and update the local formData.
+watch(() => store.transactionForm, (newFormState) => {
+  formData.value = { ...newFormState }; // Create a copy
+}, { deep: true, immediate: true }); // immediate to set initial state
+
+// Also, if the form is closed, we might want to reset the local formData
+// or rely on store.transactionForm being reset when opened.
+// The current store logic resets transactionForm when openNewTransactionForm is called.
+
+const handleSubmit = () => {
+  // Update the store's transactionForm with the local formData before saving
+  // This step ensures that the store action has the latest data from the form.
+  // Alternatively, the store action could accept formData as a payload.
+  store.transactionForm.description = formData.value.description;
+  store.transactionForm.amount = formData.value.amount;
+  store.transactionForm.date = formData.value.date;
+  store.transactionForm.detail = formData.value.detail;
+  store.transactionForm.type = formData.value.type;
+  store.transactionForm.category = formData.value.type === 'income' ? '' : formData.value.category; // Clear category for income
+  store.transactionForm.member = formData.value.member;
+  // ID and isEditing are already part of store.transactionForm
+
+  store.saveTransaction();
+  // The store action will set showTransactionForm to false
+};
+</script>

--- a/vue-tailwind-dashboard/src/components/TransactionList.vue
+++ b/vue-tailwind-dashboard/src/components/TransactionList.vue
@@ -1,0 +1,110 @@
+<template>
+  <div class="bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+    <div class="flex justify-between items-center mb-4">
+      <h2 class="text-xl font-bold text-slate-800">Transacciones Recientes</h2>
+      <div class="flex gap-2">
+        <button
+          @click="askToClearTransactions"
+          v-if="store.transactions.length > 0"
+          class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-4 rounded-lg flex items-center justify-center text-sm"
+        >
+          <font-awesome-icon icon="trash-alt" class="mr-2" />
+          <span>Vaciar Lista</span>
+        </button>
+        <button
+          @click="store.openNewTransactionForm()"
+          class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition-transform transform hover:scale-105 flex items-center justify-center text-sm"
+        >
+          <font-awesome-icon icon="plus" class="mr-2" />
+          <span>Añadir Transacción</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="overflow-x-auto">
+      <table class="w-full text-left">
+        <thead>
+          <tr class="border-b-2 border-slate-200">
+            <th class="py-3 px-2 font-semibold text-sm text-slate-500">Descripción</th>
+            <th class="py-3 px-2 font-semibold text-sm text-slate-500 hidden sm:table-cell">Miembro</th>
+            <th class="py-3 px-2 font-semibold text-sm text-slate-500 hidden md:table-cell">Categoría</th>
+            <th class="py-3 px-2 font-semibold text-sm text-slate-500 text-right">Monto</th>
+            <th class="py-3 px-2 font-semibold text-sm text-slate-500 text-center">Acciones</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="store.groupedTransactions.length === 0">
+            <td colspan="5" class="text-center py-8 text-slate-500">
+              No hay transacciones en el rango seleccionado o no hay transacciones aún.
+            </td>
+          </tr>
+          <template v-for="group in store.groupedTransactions" :key="group.date">
+            <tr class="bg-slate-100 sticky top-0 z-10">
+              <td colspan="5" class="py-2 px-2 text-sm font-bold text-slate-600 capitalize">
+                {{ fDateHeader(group.date) }}
+              </td>
+            </tr>
+            <tr v-for="t in group.transactions" :key="t.id" class="border-b border-slate-100 hover:bg-slate-50">
+              <td class="py-3 px-2">
+                <p class="font-medium text-slate-800">{{ t.description }}</p>
+                <p v-if="t.detail" class="text-xs text-slate-500 mt-1 italic">{{ t.detail }}</p>
+                <span class="block sm:hidden text-xs text-slate-400 mt-1">{{ t.member }} / {{ t.category }}</span>
+              </td>
+              <td class="py-3 px-2 hidden sm:table-cell">{{ t.member }}</td>
+              <td class="py-3 px-2 hidden md:table-cell">
+                <span
+                  v-if="t.type === 'expense' && t.category"
+                  class="px-2 py-1 text-xs rounded-full font-medium"
+                  :style="{
+                    backgroundColor: getCategoryStyle(store.getCategoryColor(t.category), 0.2).backgroundColor,
+                    color: getCategoryStyle(store.getCategoryColor(t.category), 1).borderColor
+                  }"
+                >
+                  {{ t.category }}
+                </span>
+              </td>
+              <td class="py-3 px-2 text-right font-mono" :class="t.type === 'income' ? 'text-green-600' : 'text-red-600'">
+                {{ t.type === 'income' ? '+' : '-' }} {{ fCurrency(t.amount, false) }}
+              </td>
+              <td class="py-3 px-2 text-center">
+                <div class="flex justify-center items-center gap-3">
+                  <button @click="edit(t)" class="text-slate-400 hover:text-blue-500 transition-colors">
+                    <font-awesome-icon icon="pencil-alt" />
+                  </button>
+                  <button @click="askToDelete(t.id)" class="text-slate-400 hover:text-red-500 transition-colors">
+                    <font-awesome-icon icon="trash-alt" />
+                  </button>
+                </div>
+              </td>
+            </tr>
+          </template>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useMainStore } from '../store/mainStore';
+import { formatCurrency as fCurrency, formatDateHeader as fDateHeader, getCategoryStyle } from '../utils/formatters';
+
+const store = useMainStore();
+
+const edit = (transaction) => store.openEditTransactionForm(transaction);
+
+const askToDelete = (id) => {
+  store.openConfirmModal(
+    'Eliminar Transacción',
+    '¿Estás seguro de que quieres eliminar esta transacción?',
+    () => store.deleteTransaction(id)
+  );
+};
+
+const askToClearTransactions = () => {
+  store.openConfirmModal(
+    'Vaciar Lista de Transacciones',
+    '¿Estás seguro de que quieres eliminar TODAS las transacciones? Esta acción no se puede deshacer.',
+    () => store.clearAllTransactions()
+  );
+};
+</script>

--- a/vue-tailwind-dashboard/src/components/charts/CategoryChart.vue
+++ b/vue-tailwind-dashboard/src/components/charts/CategoryChart.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+    <h2 class="text-xl font-bold mb-4 text-slate-800">Gastos por Categoría</h2>
+    <canvas ref="chartCanvasRef"></canvas>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue';
+import { useMainStore } from '../../store/mainStore';
+import Chart from 'chart.js/auto';
+
+const store = useMainStore();
+const chartCanvasRef = ref(null);
+let chartInstance = null;
+
+const renderChart = async () => {
+  await nextTick();
+  if (chartInstance) {
+    chartInstance.destroy();
+  }
+  if (!chartCanvasRef.value || Object.keys(store.expensesByCategory).length === 0) return;
+
+  const categoryData = Object.keys(store.expensesByCategory);
+  const categoryValues = Object.values(store.expensesByCategory);
+
+  const backgroundColors = categoryData.map(cat => {
+    const hexColor = store.getCategoryColor(cat);
+    let r=0,g=0,b=0;
+    if(hexColor.length==7){r=parseInt(hexColor.substring(1,3),16);g=parseInt(hexColor.substring(3,5),16);b=parseInt(hexColor.substring(5,7),16);}
+    else if (hexColor.length==4){r=parseInt(hexColor.substring(1,2)+hexColor.substring(1,2),16);g=parseInt(hexColor.substring(2,3)+hexColor.substring(2,3),16);b=parseInt(hexColor.substring(3,4)+hexColor.substring(3,4),16);}
+    return `rgba(${r},${g},${b},0.8)`;
+  });
+
+  chartInstance = new Chart(chartCanvasRef.value, {
+    type: 'doughnut',
+    data: {
+      labels: categoryData,
+      datasets: [{
+        data: categoryValues,
+        backgroundColor: backgroundColors,
+        borderColor: '#ffffff',
+        borderWidth: 2,
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: true, // Or false depending on desired behavior
+      plugins: { legend: { position: 'bottom' }}
+    }
+  });
+};
+
+onMounted(renderChart);
+onUnmounted(() => {
+  if (chartInstance) {
+    chartInstance.destroy();
+  }
+});
+
+// Watch for changes in filtered transactions or categories (which might change colors)
+watch(() => [store.filteredTransactions, store.categories], renderChart, { deep: true });
+</script>

--- a/vue-tailwind-dashboard/src/components/charts/MemberChart.vue
+++ b/vue-tailwind-dashboard/src/components/charts/MemberChart.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="bg-white p-6 rounded-xl shadow-lg border border-slate-200">
+    <h2 class="text-xl font-bold mb-4 text-slate-800">Gastos por Miembro</h2>
+    <canvas ref="chartCanvasRef"></canvas>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue';
+import { useMainStore } from '../../store/mainStore';
+import Chart from 'chart.js/auto';
+
+const store = useMainStore();
+const chartCanvasRef = ref(null);
+let chartInstance = null;
+
+const renderChart = async () => {
+  await nextTick();
+  if (chartInstance) {
+    chartInstance.destroy();
+  }
+  if (!chartCanvasRef.value || Object.keys(store.expensesByMember).length === 0) return;
+
+  const memberData = Object.keys(store.expensesByMember);
+  const memberValues = Object.values(store.expensesByMember);
+
+  chartInstance = new Chart(chartCanvasRef.value, {
+    type: 'bar',
+    data: {
+      labels: memberData,
+      datasets: [{
+        label: 'Gasto Total',
+        data: memberValues,
+        backgroundColor: memberData.map((_, i) => `hsla(${i * 45}, 70%, 60%, 0.8)`), // Simple distinct colors
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: true,
+      plugins: { legend: { display: false }},
+      scales: { y: { beginAtZero: true }}
+    }
+  });
+};
+
+onMounted(renderChart);
+onUnmounted(() => {
+  if (chartInstance) {
+    chartInstance.destroy();
+  }
+});
+
+watch(() => store.filteredTransactions, renderChart, { deep: true });
+</script>

--- a/vue-tailwind-dashboard/src/main.js
+++ b/vue-tailwind-dashboard/src/main.js
@@ -1,0 +1,21 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia'; // Import Pinia
+import App from './App.vue';
+import router from './router';
+import './style.css';
+
+// Font Awesome
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { fas } from '@fortawesome/free-solid-svg-icons';
+
+library.add(fas);
+
+const app = createApp(App);
+const pinia = createPinia(); // Create Pinia instance
+
+app.use(pinia); // Use Pinia
+app.use(router);
+app.component('font-awesome-icon', FontAwesomeIcon);
+
+app.mount('#app');

--- a/vue-tailwind-dashboard/src/router/index.js
+++ b/vue-tailwind-dashboard/src/router/index.js
@@ -1,0 +1,40 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import DashboardView from '../views/DashboardView.vue';
+import ChartsView from '../views/ChartsView.vue';
+import MembersView from '../views/MembersView.vue';
+import CategoriesView from '../views/CategoriesView.vue';
+
+const routes = [
+  {
+    path: '/',
+    name: 'Dashboard',
+    component: DashboardView,
+  },
+  {
+    path: '/charts',
+    name: 'Charts',
+    component: ChartsView,
+  },
+  {
+    path: '/members',
+    name: 'Members',
+    component: MembersView,
+  },
+  {
+    path: '/categories',
+    name: 'Categories',
+    component: CategoriesView,
+  },
+  // Redirect to Dashboard for any unknown paths
+  {
+    path: '/:catchAll(.*)',
+    redirect: '/',
+  }
+];
+
+const router = createRouter({
+  history: createWebHistory(import.meta.env.BASE_URL), // Vite's import.meta.env.BASE_URL for base path
+  routes,
+});
+
+export default router;

--- a/vue-tailwind-dashboard/src/services/localStorageService.js
+++ b/vue-tailwind-dashboard/src/services/localStorageService.js
@@ -1,0 +1,58 @@
+const TRANSACTIONS_KEY = 'family-transactions';
+const MEMBERS_KEY = 'family-members';
+const CATEGORIES_KEY = 'family-categories';
+
+export const loadTransactions = () => {
+  const data = localStorage.getItem(TRANSACTIONS_KEY);
+  return data ? JSON.parse(data) : [];
+};
+
+export const saveTransactions = (transactions) => {
+  localStorage.setItem(TRANSACTIONS_KEY, JSON.stringify(transactions));
+};
+
+export const loadMembers = () => {
+  const data = localStorage.getItem(MEMBERS_KEY);
+  return data ? JSON.parse(data) : ['Padre', 'Madre', 'Hijo', 'Hija', 'Familia']; // Default if not found
+};
+
+export const saveMembers = (members) => {
+  localStorage.setItem(MEMBERS_KEY, JSON.stringify(members));
+};
+
+export const loadCategories = () => {
+  const data = localStorage.getItem(CATEGORIES_KEY);
+  // Default categories if not found
+  const defaultCategories = [
+    { name: 'Comida', color: '#4ade80' }, { name: 'Transporte', color: '#60a5fa' },
+    { name: 'Vivienda', color: '#facc15' }, { name: 'Ocio', color: '#fb923c' },
+    { name: 'Salud', color: '#f87171' }, { name: 'Educación', color: '#c084fc' },
+    { name: 'Ropa', color: '#ec4899' }, { name: 'Otros', color: '#94a3b8' }
+  ];
+  return data ? JSON.parse(data) : defaultCategories;
+};
+
+export const saveCategories = (categories) => {
+  localStorage.setItem(CATEGORIES_KEY, JSON.stringify(categories));
+};
+
+export const exportData = () => {
+  const dataToExport = {
+    transactions: loadTransactions(),
+    members: loadMembers(),
+    categories: loadCategories(),
+  };
+  const jsonString = JSON.stringify(dataToExport, null, 2);
+  const blob = new Blob([jsonString], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `dashboard-gastos-${new Date().toISOString().slice(0, 10)}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+// handleFileUpload logic will likely be part of a component that uses this service or a store action
+// For now, the core load/save operations are here.

--- a/vue-tailwind-dashboard/src/store/mainStore.js
+++ b/vue-tailwind-dashboard/src/store/mainStore.js
@@ -1,0 +1,268 @@
+import { defineStore } from 'pinia';
+import { ref, computed, watch } from 'vue';
+import * as storage from '../services/localStorageService'; // Using * as storage
+
+export const useMainStore = defineStore('main', () => {
+  // --- STATE ---
+  const transactions = ref(storage.loadTransactions());
+  const members = ref(storage.loadMembers());
+  const categories = ref(storage.loadCategories());
+
+  const filterStartDate = ref('');
+  const filterEndDate = ref('');
+
+  // --- MODAL & FORM STATE (Consider if these should be global or local) ---
+  // For now, keeping transaction form visibility global as it was in original App.vue concept
+  const showTransactionForm = ref(false);
+  const transactionFormInitialState = () => ({
+    id: null, description: '', amount: null, type: 'expense', category: '', member: '',
+    date: new Date().toISOString().slice(0, 10), detail: '', isEditing: false,
+  });
+  const transactionForm = ref(transactionFormInitialState());
+
+  const showConfirmModal = ref(false);
+  const confirmModalProps = ref({ title: '', message: '', onConfirm: () => {} });
+
+  // --- WATCHERS FOR PERSISTENCE ---
+  watch(transactions, (newTransactions) => {
+    storage.saveTransactions(newTransactions);
+  }, { deep: true });
+
+  watch(members, (newMembers) => {
+    storage.saveMembers(newMembers);
+  }, { deep: true });
+
+  watch(categories, (newCategories) => {
+    storage.saveCategories(newCategories);
+  }, { deep: true });
+
+  // --- COMPUTED ---
+  const filteredTransactions = computed(() => {
+    return transactions.value.filter(t => {
+      const transactionDate = new Date(t.date);
+      const startDate = filterStartDate.value ? new Date(filterStartDate.value) : null;
+      const endDate = filterEndDate.value ? new Date(filterEndDate.value) : null;
+      if (startDate) startDate.setUTCHours(0, 0, 0, 0);
+      if (endDate) endDate.setUTCHours(23, 59, 59, 999);
+      if (startDate && transactionDate < startDate) return false;
+      if (endDate && transactionDate > endDate) return false;
+      return true;
+    }).sort((a, b) => new Date(b.date) - new Date(a.date)); // Sort by date descending
+  });
+
+  const totalIncome = computed(() =>
+    filteredTransactions.value
+      .filter(t => t.type === 'income')
+      .reduce((sum, t) => sum + Number(t.amount), 0)
+  );
+
+  const totalExpense = computed(() =>
+    filteredTransactions.value
+      .filter(t => t.type === 'expense')
+      .reduce((sum, t) => sum + Number(t.amount), 0)
+  );
+
+  const balance = computed(() => totalIncome.value - totalExpense.value);
+
+  const expensesByCategory = computed(() => {
+    return filteredTransactions.value
+      .filter(t => t.type === 'expense')
+      .reduce((acc, t) => {
+        acc[t.category] = (acc[t.category] || 0) + Number(t.amount);
+        return acc;
+      }, {});
+  });
+
+  const expensesByMember = computed(() => {
+    return filteredTransactions.value
+      .filter(t => t.type === 'expense')
+      .reduce((acc, t) => {
+        acc[t.member] = (acc[t.member] || 0) + Number(t.amount);
+        return acc;
+      }, {});
+  });
+
+  const groupedTransactions = computed(() => {
+    // Assuming filteredTransactions is already sorted by date descending
+    const groups = filteredTransactions.value.reduce((acc, transaction) => {
+        const date = transaction.date; // Already YYYY-MM-DD
+        if (!acc[date]) acc[date] = [];
+        acc[date].push(transaction);
+        return acc;
+    }, {});
+    return Object.keys(groups)
+        .sort((a,b) => new Date(b) - new Date(a)) // Sort dates descending
+        .map(date => ({ date: date, transactions: groups[date] }));
+  });
+
+
+  // --- ACTIONS ---
+  // Transaction Actions
+  const openNewTransactionForm = () => {
+    transactionForm.value = transactionFormInitialState();
+    showTransactionForm.value = true;
+  };
+
+  const openEditTransactionForm = (transaction) => {
+    transactionForm.value = { ...transaction, isEditing: true };
+    showTransactionForm.value = true;
+  };
+
+  const saveTransaction = () => {
+    const form = transactionForm.value;
+    // Basic validation
+    if (!form.description || !form.amount || !form.member || !form.date) return;
+    if (form.type === 'expense' && !form.category) return;
+
+    const newTransaction = { ...form, amount: Number(form.amount) };
+    if (form.isEditing) {
+      const index = transactions.value.findIndex(t => t.id === form.id);
+      if (index !== -1) {
+        transactions.value[index] = newTransaction;
+      }
+    } else {
+      transactions.value.unshift({ ...newTransaction, id: Date.now() });
+    }
+    showTransactionForm.value = false;
+  };
+
+  const deleteTransaction = (id) => {
+    transactions.value = transactions.value.filter(t => t.id !== id);
+  };
+
+  const clearAllTransactions = () => {
+    transactions.value = [];
+  };
+
+  // Member Actions
+  const addMember = (name) => {
+    if (name && !members.value.includes(name)) {
+      members.value.push(name);
+    }
+  };
+  const updateMember = (oldName, newName) => {
+    if (!newName || oldName === newName) return;
+    if (members.value.includes(newName)) {
+      alert('Este nombre de miembro ya existe.'); return false;
+    }
+    const index = members.value.findIndex(m => m === oldName);
+    if (index !== -1) {
+      members.value[index] = newName;
+      // Update transactions
+      transactions.value.forEach(t => {
+        if (t.member === oldName) t.member = newName;
+      });
+    }
+    return true;
+  };
+  const deleteMember = (name) => {
+    if (transactions.value.some(t => t.member === name)) {
+      alert(`No se puede eliminar a "${name}" porque tiene transacciones asociadas.`);
+      return false;
+    }
+    members.value = members.value.filter(m => m !== name);
+    return true;
+  };
+
+  // Category Actions
+  const addCategory = (category) => { // category is { name, color }
+    if (category.name && !categories.value.some(c => c.name === category.name)) {
+      categories.value.push(category);
+    }
+  };
+  const updateCategory = (oldName, newCategory) => { // newCategory is { name, color }
+     if (!newCategory.name) return false;
+    if (oldName !== newCategory.name && categories.value.some(c => c.name === newCategory.name)) {
+      alert('Ese nombre de categoría ya existe.'); return false;
+    }
+    const categoryToUpdate = categories.value.find(c => c.name === oldName);
+    if (categoryToUpdate) {
+      categoryToUpdate.name = newCategory.name;
+      categoryToUpdate.color = newCategory.color;
+      transactions.value.forEach(t => {
+        if (t.category === oldName) t.category = newCategory.name;
+      });
+    }
+    return true;
+  };
+  const deleteCategory = (name) => {
+    if (transactions.value.some(t => t.type === 'expense' && t.category === name)) {
+      alert(`No se puede eliminar "${name}" porque tiene transacciones asociadas.`);
+      return false;
+    }
+    categories.value = categories.value.filter(c => c.name !== name);
+    return true;
+  };
+
+  const getCategoryColor = (categoryName) => {
+    const category = categories.value.find(c => c.name === categoryName);
+    return category ? category.color : '#94a3b8'; // Default color
+  };
+
+
+  // Filter Actions
+  const resetDateFilters = () => {
+    filterStartDate.value = '';
+    filterEndDate.value = '';
+  };
+
+  // Confirmation Modal Actions
+  const openConfirmModal = (title, message, onConfirmAction) => {
+    confirmModalProps.value = { title, message, onConfirm: onConfirmAction };
+    showConfirmModal.value = true;
+  };
+  const closeConfirmModal = () => {
+    showConfirmModal.value = false;
+  };
+  const executeConfirm = () => {
+    if (confirmModalProps.value.onConfirm) {
+      confirmModalProps.value.onConfirm();
+    }
+    closeConfirmModal();
+  };
+
+  // Import/Export
+  const handleFileUpload = (file) => {
+    // This function will read the file and then likely call another action to process the data
+    // For example, it might parse the JSON and then call openConfirmModal
+    // The actual file reading logic might be better in the component, passing the parsed data to an action
+    const reader = new FileReader();
+    reader.onload = (e) => {
+        try {
+            const importedData = JSON.parse(e.target.result);
+            if (importedData && importedData.transactions && importedData.members && importedData.categories) {
+                openConfirmModal(
+                    'Importar Datos',
+                    'Esto reemplazará todos los datos actuales. ¿Deseas continuar?',
+                    () => {
+                        transactions.value = importedData.transactions || [];
+                        members.value = importedData.members || [];
+                        categories.value = importedData.categories || [];
+                        // Data will be saved by watchers
+                    }
+                );
+            } else {
+                alert('El archivo no tiene el formato correcto.');
+            }
+        } catch (error) {
+            alert('Error al leer el archivo. Asegúrate de que sea un archivo JSON válido.');
+        }
+    };
+    reader.readAsText(file);
+  };
+
+
+  return {
+    transactions, members, categories, filterStartDate, filterEndDate,
+    showTransactionForm, transactionForm, transactionFormInitialState,
+    showConfirmModal, confirmModalProps,
+    filteredTransactions, totalIncome, totalExpense, balance, expensesByCategory, expensesByMember, groupedTransactions,
+    openNewTransactionForm, openEditTransactionForm, saveTransaction, deleteTransaction, clearAllTransactions,
+    addMember, updateMember, deleteMember,
+    addCategory, updateCategory, deleteCategory, getCategoryColor,
+    resetDateFilters,
+    openConfirmModal, closeConfirmModal, executeConfirm,
+    exportData: storage.exportData, // Use directly from service
+    handleFileUpload,
+  };
+});

--- a/vue-tailwind-dashboard/src/style.css
+++ b/vue-tailwind-dashboard/src/style.css
@@ -1,0 +1,1 @@
+@import './assets/css/main.css';

--- a/vue-tailwind-dashboard/src/utils/formatters.js
+++ b/vue-tailwind-dashboard/src/utils/formatters.js
@@ -1,0 +1,66 @@
+export const formatCurrency = (value, includeSymbol = true, currency = 'PEN', locale = 'es-PE') => {
+  const amount = Number(value) || 0;
+  const options = { style: 'currency', currency: currency, minimumFractionDigits: 2, maximumFractionDigits: 2 };
+  if (!includeSymbol) {
+    delete options.style;
+    delete options.currency;
+  }
+  return new Intl.NumberFormat(locale, options).format(amount);
+};
+
+export const formatDateHeader = (dateString) => {
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+
+  // Ensure dateString is treated as UTC to avoid timezone shifts from new Date()
+  // Handles cases where dateString might already be a Date object or a string
+  let transactionDate;
+  if (dateString instanceof Date) {
+    transactionDate = new Date(Date.UTC(dateString.getUTCFullYear(), dateString.getUTCMonth(), dateString.getUTCDate()));
+  } else {
+    const parts = String(dateString).split('-'); // YYYY-MM-DD
+    transactionDate = new Date(Date.UTC(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2])));
+  }
+
+  const todayUTC = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate()));
+  const yesterdayUTC = new Date(Date.UTC(yesterday.getUTCFullYear(), yesterday.getUTCMonth(), yesterday.getUTCDate()));
+
+  if (transactionDate.getTime() === todayUTC.getTime()) return 'Hoy';
+  if (transactionDate.getTime() === yesterdayUTC.getTime()) return 'Ayer';
+
+  return new Intl.DateTimeFormat('es-ES', { dateStyle: 'full' }).format(transactionDate);
+};
+
+// Could add getCategoryBgColor here too if it's used in multiple places without store access
+// export const getCategoryStyle = (hexColor, opacity = 1) => { ... }
+
+
+export const getCategoryStyle = (hexColor, opacity = 1) => {
+  if (!hexColor) { // Default color if none provided
+    hexColor = '#94a3b8'; // slate-400 or similar
+  }
+  let r = 0, g = 0, b = 0;
+  if (hexColor.length === 7) { // #RRGGBB
+    r = parseInt(hexColor.substring(1, 3), 16);
+    g = parseInt(hexColor.substring(3, 5), 16);
+    b = parseInt(hexColor.substring(5, 7), 16);
+  } else if (hexColor.length === 4) { // #RGB
+    r = parseInt(hexColor.substring(1, 2) + hexColor.substring(1, 2), 16);
+    g = parseInt(hexColor.substring(2, 3) + hexColor.substring(2, 3), 16);
+    b = parseInt(hexColor.substring(3, 4) + hexColor.substring(3, 4), 16);
+  } else { // Fallback for invalid hex
+    hexColor = '#94a3b8';
+    r = parseInt(hexColor.substring(1, 3), 16);
+    g = parseInt(hexColor.substring(3, 5), 16);
+    b = parseInt(hexColor.substring(5, 7), 16);
+  }
+
+  const textColor = (r * 0.299 + g * 0.587 + b * 0.114) > 186 ? '#000000' : '#FFFFFF'; // Determine if black or white text is more readable
+
+  return {
+    backgroundColor: `rgba(${r},${g},${b},${opacity})`,
+    color: textColor, // Return text color for better contrast if needed directly
+    borderColor: `rgb(${r},${g},${b})` // Full opacity border
+  };
+};

--- a/vue-tailwind-dashboard/src/views/CategoriesView.vue
+++ b/vue-tailwind-dashboard/src/views/CategoriesView.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="bg-white p-6 sm:p-8 rounded-xl shadow-lg border border-slate-200">
+    <h2 class="text-xl font-bold mb-6 text-slate-800">Gestionar Categorías</h2>
+    <CategoryManager />
+  </div>
+</template>
+
+<script setup>
+import CategoryManager from '../components/CategoryManager.vue';
+</script>

--- a/vue-tailwind-dashboard/src/views/ChartsView.vue
+++ b/vue-tailwind-dashboard/src/views/ChartsView.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="space-y-8">
+    <DateFilter />
+    <div v-if="store.totalExpense === 0" class="text-center py-16 text-slate-500 bg-white rounded-xl shadow-lg">
+      <font-awesome-icon icon="chart-pie" class="fa-3x mb-4 text-slate-400" />
+      <h3 class="text-xl font-bold">No hay datos de gastos para mostrar.</h3>
+      <p>Añade algunas transacciones de gastos para ver los gráficos.</p>
+    </div>
+    <div v-else class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <CategoryChart />
+      <MemberChart />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useMainStore } from '../store/mainStore';
+import DateFilter from '../components/DateFilter.vue';
+import CategoryChart from '../components/charts/CategoryChart.vue';
+import MemberChart from '../components/charts/MemberChart.vue';
+
+const store = useMainStore();
+</script>

--- a/vue-tailwind-dashboard/src/views/DashboardView.vue
+++ b/vue-tailwind-dashboard/src/views/DashboardView.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="space-y-8">
+    <DateFilter v-if="!store.showTransactionForm" /> <!-- Hide filter when form is shown, or handle layout differently -->
+
+    <section class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+      <StatsCard
+        title="Ingresos Totales"
+        :value="store.totalIncome"
+        icon="arrow-up"
+        icon-bg-color="bg-green-100"
+        icon-text-color="text-green-600"
+        value-text-color="text-green-600"
+      />
+      <StatsCard
+        title="Gastos Totales"
+        :value="store.totalExpense"
+        icon="arrow-down"
+        icon-bg-color="bg-red-100"
+        icon-text-color="text-red-600"
+        value-text-color="text-red-600"
+      />
+      <StatsCard
+        title="Balance Actual"
+        :value="store.balance"
+        icon="wallet"
+        icon-bg-color="bg-blue-100"
+        icon-text-color="text-blue-600"
+        :value-text-color="store.balance < 0 ? 'text-red-600' : 'text-green-600'"
+      />
+    </section>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <div class="lg:col-span-2">
+        <TransactionList />
+      </div>
+      <CategoryList />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useMainStore } from '../store/mainStore';
+import DateFilter from '../components/DateFilter.vue';
+import StatsCard from '../components/StatsCard.vue';
+import TransactionList from '../components/TransactionList.vue';
+import CategoryList from '../components/CategoryList.vue';
+
+const store = useMainStore();
+</script>

--- a/vue-tailwind-dashboard/src/views/MembersView.vue
+++ b/vue-tailwind-dashboard/src/views/MembersView.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="bg-white p-6 sm:p-8 rounded-xl shadow-lg border border-slate-200">
+    <h2 class="text-xl font-bold mb-6 text-slate-800">Gestionar Miembros de la Familia</h2>
+    <MemberListManager />
+  </div>
+</template>
+
+<script setup>
+import MemberListManager from '../components/MemberListManager.vue';
+</script>

--- a/vue-tailwind-dashboard/tailwind.config.js
+++ b/vue-tailwind-dashboard/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+    module.exports = {
+      content: [
+        "./index.html",
+        "./src/**/*.{vue,js,ts,jsx,tsx}",
+      ],
+      theme: {
+        extend: {},
+      },
+      plugins: [],
+    }

--- a/vue-tailwind-dashboard/vite.config.js
+++ b/vue-tailwind-dashboard/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [vue()],
+})


### PR DESCRIPTION
- Initializes project with Vite and Vue 3.
- Integrates Tailwind CSS for styling.
- Structures application into components, views, services, and a Pinia store.
- Migrates all existing functionality from the original HTML/Vue 2 setup:
  - Transaction CRUD and display (grouped by date).
  - Member CRUD and display.
  - Category CRUD and display (with color picker).
  - Dashboard view with summary stats (income, expense, balance) and category expense breakdown.
  - Charts view for expenses by category and member using Chart.js.
  - Date filtering for transactions and charts.
  - JSON data import and export.
- Implements global state management with Pinia.
- Centralizes localStorage interactions in a service.
- Refactors utility functions (formatting) into a utils module.
- Removes unused Vite default files.
- Ensures basic styling and transitions are preserved/re-implemented.