### PR TITLE
Fix: Rename postcss.config.js to .cjs for ES module compatibility

### DIFF
--- a/vue-tailwind-dashboard/postcss.config.cjs
+++ b/vue-tailwind-dashboard/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/vue-tailwind-dashboard/postcss.config.js
+++ b/vue-tailwind-dashboard/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-      plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-      },
-    }


### PR DESCRIPTION
Renames postcss.config.js to postcss.config.cjs to ensure it is treated as a CommonJS module.

This resolves an error where PostCSS failed to load its configuration due to the project being an ES module (type: "module" in package.json) while the config file used CommonJS (module.exports) syntax. Using the .cjs extension clarifies the module format for Node.js and Vite.