### PR TITLE
Fix: Update PostCSS config for Tailwind CSS v4

### DIFF
--- a/vue-tailwind-dashboard/postcss.config.cjs
+++ b/vue-tailwind-dashboard/postcss.config.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }

--- a/vue-tailwind-dashboard/src/style.css
+++ b/vue-tailwind-dashboard/src/style.css
@@ -1,1 +1,2 @@
+@import "tailwindcss";
 @import './assets/css/main.css';


### PR DESCRIPTION
- Updated `postcss.config.cjs` to use `@tailwindcss/postcss`.
- Added `@import "tailwindcss";` to `src/style.css` as per Tailwind v4 requirements.

This resolves the PostCSS error related to the direct use of the `tailwindcss` plugin.