### PR TITLE
Fix: Configure path alias for Vite

### DIFF
--- a/vue-tailwind-dashboard/vite.config.js
+++ b/vue-tailwind-dashboard/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
+import path from 'path' // Necesario para resolve.alias
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
 })


### PR DESCRIPTION
Se añadió la configuración de alias a `vite.config.js` para que `@` se resuelva a la carpeta `src`. Esto corrige los errores de resolución de dependencias durante el pre-bundling de Vite.