### PR TITLE
fix: Prevent error in formatCurrency due to uninitialized store data

### DIFF
--- a/vue-tailwind-dashboard/src/store/mainStore.js
+++ b/vue-tailwind-dashboard/src/store/mainStore.js
@@ -7,9 +7,10 @@ export const useMainStore = defineStore('main', () => {
   const transactions = ref(storage.loadTransactions());
   const members = ref(storage.loadMembers());
   const categories = ref(storage.loadCategories());
-  const activeCurrencies = ref(storage.loadActiveCurrencies()); // Load all available currencies
-  const exchangeRates = ref(storage.loadExchangeRates()); // Load exchange rates
-  const selectedCurrencyCode = ref(storage.loadSelectedCurrencyCode()); // Load user's preferred currency
+  // Initialize with empty array/object to prevent undefined errors on initial access
+  const activeCurrencies = ref(storage.loadActiveCurrencies() || []);
+  const exchangeRates = ref(storage.loadExchangeRates() || {});
+  const selectedCurrencyCode = ref(storage.loadSelectedCurrencyCode() || 'PEN'); // Default to PEN if load returns null/undefined
 
   const filterStartDate = ref('');
   const filterEndDate = ref('');


### PR DESCRIPTION
- Initialize `activeCurrencies` and `exchangeRates` in `mainStore.js` with empty array/object fallbacks to ensure they are never undefined.
- Initialize `selectedCurrencyCode` with a 'PEN' fallback.
- Added robust checks in `formatCurrency` in `formatters.js` to handle cases where currency or rate data might be missing or invalid, preventing runtime errors like 'Cannot read properties of undefined (reading "find")'.